### PR TITLE
`parse_pac_file` now raises IOError

### DIFF
--- a/src/pymod/pacparser/__init__.py
+++ b/src/pymod/pacparser/__init__.py
@@ -53,13 +53,11 @@ def parse_pac_file(pacfile):
   init().
   """
   try:
-    f = open(pacfile)
-    pac_script = f.read()
+    with open(pacfile) as f:
+      pac_script = f.read()
+      _pacparser.parse_pac_string(pac_script)
   except IOError:
-    print('Could not read the pacfile: %s\n%s' % (pacfile, sys.exc_info()[1]))
-    return
-  f.close()
-  _pacparser.parse_pac_string(pac_script)
+    raise IOError('Could not read the pacfile.')
 
 def parse_pac_string(pac_script):
   """


### PR DESCRIPTION
If the file containing pac information is not readable or does not
exist the current way of handling this is inadiquate (the exception
caught in the function and a print message sent to stdout via `print`).

This could and should be improved massively by sending back to the user
an IOError which can be handled in a sensible manner.

https://github.com/pacparser/pacparser/issues/42