### PR TITLE
Quote the path to make to support paths with spaces.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -79,11 +79,11 @@ spidermonkey/js/src: spidermonkey/js-?.?.?.tar.gz
 	sed -i -e 's:\(shell uname -s | sed /\\ /s//_/\):\1 | sed s,GNU.*,Linux,:g' spidermonkey/js/src/config.mk
 
 jsapi_buildstamp: spidermonkey/js/src
-	cd spidermonkey && SMCFLAGS="$(SHFLAGS) $(SMCFLAGS)" $(MAKE) jsapi
+	cd spidermonkey && SMCFLAGS="$(SHFLAGS) $(SMCFLAGS)" "$(MAKE)" jsapi
 	touch jsapi_buildstamp
 
 libjs.a: spidermonkey/js/src
-	cd spidermonkey && SMCFLAGS="$(SHFLAGS) $(SMCFLAGS)" $(MAKE) jslib
+	cd spidermonkey && SMCFLAGS="$(SHFLAGS) $(SMCFLAGS)" "$(MAKE)" jslib
 
 pacparser.o: pacparser.c pac_utils.h pacparser.h jsapi_buildstamp
 	$(CC) $(CFLAGS) $(SHFLAGS) -c pacparser.c -o pacparser.o
@@ -135,4 +135,4 @@ install-pymod: pymod
 clean:
 	rm -f $(LIBRARY_LINK) $(LIBRARY) libjs.a pacparser.o pactester pymod/pacparser_o_buildstamp jsapi_buildstamp
 	cd pymod && python setup.py clean --all
-	cd spidermonkey && $(MAKE) clean
+	cd spidermonkey && "$(MAKE)" clean

--- a/src/spidermonkey/Makefile
+++ b/src/spidermonkey/Makefile
@@ -34,7 +34,7 @@ jslib: js-buildstamp
 
 js-buildstamp:
 	mkdir -p js/src/$(OBJDIR)
-	CFLAGS="$(SMCFLAGS)" $(MAKE) -C js/src -f Makefile.ref libjs.a
+	CFLAGS="$(SMCFLAGS)" "$(MAKE)" -C js/src -f Makefile.ref libjs.a
 	find js/src -name "jsautocfg.h" -exec cp {} js/src \;
 	touch js-buildstamp
 


### PR DESCRIPTION
Changing to:

    cd spidermonkey && SMCFLAGS=" -DHAVE_VA_COPY -DVA_COPY=__va_copy" "/Volumes/Internal Disk/Applications/Xcode.app/Contents/Developer/usr/bin/make" jslib

From:

    cd spidermonkey && SMCFLAGS=" -DHAVE_VA_COPY -DVA_COPY=__va_copy" /Volumes/Internal Disk/Applications/Xcode.app/Contents/Developer/usr/bin/make jslib

—for every instance of `make`.