### PR TITLE
Remove references to code.google.com

### DIFF
--- a/docs/html/pactester.1.html
+++ b/docs/html/pactester.1.html
@@ -71,13 +71,13 @@ $ curl -s <a href='http://wpad/wpad.dat'>http://wpad/wpad.dat</a>
  
 <h2><a name='sect5' href='#toc5'>Bugs</a></h2>
 If you have come across a bug in pactester, please
-submit a bug report at <a href='http://code.google.com/p/pacparser/issues/list.'>http://code.google.com/p/pacparser/issues/list.</a>
+submit a bug report at <a href='http://github.com/pacparser/pacparser/issues.'>http://github.com/pacparser/pacparser/issues.</a>
  
 <h2><a name='sect6' href='#toc6'>Author</a></h2>
 Written
 by Manu Garg (http://www.manugarg.com). 
 <h2><a name='sect7' href='#toc7'>Resources</a></h2>
-Homepage: <a href='http://code.google.com/p/pacparser.'>http://code.google.com/p/pacparser.</a>
+Homepage: <a href='http://github.com/pacparser/pacparser.'>http://github.com/pacparser/pacparser.</a>
 
 
 <p> <p>

--- a/docs/man/man1/pactester.1
+++ b/docs/man/man1/pactester.1
@@ -46,9 +46,9 @@ For a pac file hosted at http://wpad/wpad.dat:
 $ curl \-s http://wpad/wpad.dat | pactester \-p \- \-u http://google.com
 .SH "BUGS"
 If you have come across a bug in pactester, please submit a bug report at
-http://code.google.com/p/pacparser/issues/list.
+http://github.com/pacparser/pacparser/issues.
 .SH "AUTHOR"
 Written by Manu Garg (http://www.manugarg.com).
 .SH "RESOURCES"
-Homepage: http://code.google.com/p/pacparser.
+Homepage: http://github.com/pacparser/pacparser.
 

--- a/src/pactester.c
+++ b/src/pactester.c
@@ -1,8 +1,7 @@
 // Copyright (C) 2008 Manu Garg.
 // Author: Manu Garg <manugarg@gmail.com>
 //
-// This file implements pactester (http://code.google.com/p/pactester) using
-// pacparser.
+// This file implements pactester using pacparser.
 //
 // pacparser is a library that provides methods to parse proxy auto-config
 // (PAC) files. Please read README file included with this package for more

--- a/src/pymod/pacparser/__init__.py
+++ b/src/pymod/pacparser/__init__.py
@@ -21,7 +21,7 @@
 
 """
 Python module to parse pac files. Look at project's homepage
-http://code.google.com/p/pacparser for more information.
+http://github.com/pacparser/pacparser for more information.
 """
 
 __author__ = 'manugarg@gmail.com (Manu Garg)'


### PR DESCRIPTION
This pull request fixes several references to code.google.com.  
There is one more remaining in INSTALL that I don't yet know what to do with.  It refers to http://code.google.com/p/pacparser/wiki/LinkingOnVisualStudio which already forwards to github.com but the wiki page does not exist.