### PR TITLE
Add "NO_INTERNET" description to solve runtests.py failing

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -21,6 +21,17 @@ following instructions at:
     => make -C src pymod
     => sudo make -C src install-pymod
 
+  If it failed with runtests.py when building on non interconnected hosts like this;
+  ```
+    File "../tests/runtests.py", line 79, in runtests
+    raise Exception('Tests failed. Got "%s", expected "%s"' % (result, expected_result))
+  Exception: Tests failed. Got "END-OF-SCRIPT", expected "isResolvable"
+  ```
+  Please set an environment variable NO_INTERNET. Then it won't require internet and pass the test.
+  ```
+  $ export NO_INTERNET=1 && make -C src install-pymod
+  ```
+  
 On Win-32 Systems:
 #################
 


### PR DESCRIPTION
Hi. Thanks for your great project.
I was very confused why I couldn't install. So I added a description into INSTALL doc.
I think more of people who don't connect internet directly need this library.
I appriciate it if you could accept this PR or write something anywhere to avoid the confusing to next users.

Thank you.

If it fails with runtests.py when building on non interconnected hosts like this;
  ```
    File "../tests/runtests.py", line 79, in runtests
    raise Exception('Tests failed. Got "%s", expected "%s"' % (result, expected_result))
  Exception: Tests failed. Got "END-OF-SCRIPT", expected "isResolvable"
  ```
  Please set an environment variable NO_INTERNET. Then it won't require internet.
  ```
  $ export NO_INTERNET=1 && make -C src install-pymod
  ```