### PR TITLE
fix bug in host extraction when url contains port number

### DIFF
--- a/src/pymod/pacparser/__init__.py
+++ b/src/pymod/pacparser/__init__.py
@@ -33,7 +33,7 @@ import os
 import re
 import sys
 
-_URL_REGEX = re.compile('^[^:]*:\/\/([^\/]+)')
+_URL_REGEX = re.compile('^[^:]*:\/\/([^\/:]+)')
 
 class URLError(Exception):
   def __init__(self, url):


### PR DESCRIPTION
When the url contained a port number, the logic was accidentally
including the port number when it extracted the hostname from
the url.

Signed-off-by: Martin Carroll <martin.carroll@nokia-bell-labs.com>