### PR TITLE
Update prefix for MacOS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -43,6 +43,7 @@ SHFLAGS = -fPIC
 SMCFLAGS = -DHAVE_VA_COPY -DVA_COPY=__va_copy
 
 ifeq ($(OS_ARCH),Darwin)
+  PREFIX = /usr/local
   MAC_MINOR_VERSION := $(shell sw_vers -productVersion | cut -d. -f2)
   MAC_GT_5 := $(shell [ $(MAC_MINOR_VERSION) -le 5 ] && echo false)
   SO_SUFFIX = dylib


### PR DESCRIPTION
change prefix from /usr to /usr/local to allow for MacOS systems protection. otherwise the install process gets write errors.