### PR TITLE
fix runtests.sh on alpine linux

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -97,7 +97,7 @@ pactester: pactester.c pacparser.h $(LIBRARY_LINK)
 
 testpactester: pactester
 	echo "Running tests for pactester."
-	NO_INTERNET=$(NO_INTERNET) ../tests/runtests.sh
+	NO_INTERNET=$(NO_INTERNET) /bin/sh ../tests/runtests.sh
 
 docs:
 	../tools/generatedocs.sh

--- a/src/Makefile
+++ b/src/Makefile
@@ -97,7 +97,7 @@ pactester: pactester.c pacparser.h $(LIBRARY_LINK)
 
 testpactester: pactester
 	echo "Running tests for pactester."
-	NO_INTERNET=$(NO_INTERNET) /bin/sh ../tests/runtests.sh
+	NO_INTERNET=$(NO_INTERNET) ../tests/runtests.sh
 
 docs:
 	../tools/generatedocs.sh

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # workaround for missing pushd and popd
 pushd . >/dev/null 2>&1 || alias pushd='POPDIRS="$PWD

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# workaround for missing pushd and popd
+pushd . >/dev/null 2>&1 || alias pushd='POPDIRS="$PWD
+$DIRS"; cd'
+popd >/dev/null 2>&1 || alias popd='POPLINE=`echo "\$POPDIRS" | sed -ne '1p'`;[ "$POPLINE" != "" ] && cd "$POPLINE";POPDIRS=`echo "\$POPDIRS" | sed -e '1d'`'
+
 pushd $(dirname $0) > /dev/null; script_dir=$PWD; popd > /dev/null
 
 pactester=$script_dir/../src/pactester

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 pushd $(dirname $0) > /dev/null; script_dir=$PWD; popd > /dev/null
 


### PR DESCRIPTION
tests/runtests.sh fails on alpine linux for two reasons:
* no /bin/bash (default shell is busybox)
* no push/popd (not included in default busy box shell)

This in turn causes the build to fail on alpine linux.

This pull request makes the following changes to teasts/runtests.sh:
* changes `#!/bin/bash` &rarr; `#!/bin/sh`
* checks for pushd and popd, adds dummy implementations if missing
